### PR TITLE
add Wireguard and YouTube support

### DIFF
--- a/Apps/Mullvad-browser/docker-compose.yml
+++ b/Apps/Mullvad-browser/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   app:
     image: linuxserver/mullvad-browser:13.0.14
     restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
     environment:
       PUID: $PUID
       PGID: $PGID
@@ -33,6 +35,7 @@ services:
       - type: bind
         source: /DATA/AppData/mullvad-browser/config
         target: /config
+    shm_size: "1gb"
 x-casaos:
   architectures:
     - amd64

--- a/Apps/Mullvad-browser/docker-compose.yml
+++ b/Apps/Mullvad-browser/docker-compose.yml
@@ -51,3 +51,4 @@ x-casaos:
   title:
     en_us: Mullvad browser
   category: LinuxServer.io
+  port_map: '3000'

--- a/Apps/Mullvad-browser/docker-compose.yml
+++ b/Apps/Mullvad-browser/docker-compose.yml
@@ -35,6 +35,9 @@ services:
       - type: bind
         source: /DATA/AppData/mullvad-browser/config
         target: /config
+      - type: bind
+        source: /DATA/Downloads
+        target: /config/Downloads
     shm_size: "1gb"
 x-casaos:
   architectures:


### PR DESCRIPTION
This change allows Wireguard support to function (https://github.com/linuxserver/docker-mullvad-browser/issues/9)

Also added `shm_size=“1gb”` as recommended in [LinuxServer.io README](https://github.com/linuxserver/docker-mullvad-browser?tab=readme-ov-file#parameters) for YouTube to function.
